### PR TITLE
cpuinfo: Fix WinChip and Cyrix/NSC CPU name and cache info

### DIFF
--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -108,50 +108,21 @@ void cpuid_init(void)
     }
 
     // Get cache information.
-    switch (cpuid_info.vendor_id.str[0]) {
-      case 'A':
-        // AMD Processors
-        if (cpuid_info.max_xcpuid >= 0x80000005) {
-            cpuid(0x80000005, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[0],
-                &cpuid_info.cache_info.raw[1]
-            );
-        }
-        if (cpuid_info.max_xcpuid >= 0x80000006) {
-            cpuid(0x80000006, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[2],
-                &cpuid_info.cache_info.raw[3]
-            );
-        }
-        break;
-      case 'C':
-        if (cpuid_info.vendor_id.str[5] == 'I') break; // Cyrix
-        // VIA / CentaurHauls
-        if (cpuid_info.max_xcpuid >= 0x80000005) {
-            cpuid(0x80000005, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[0],
-                &cpuid_info.cache_info.raw[1]
-            );
-        }
-        if (cpuid_info.max_xcpuid >= 0x80000006) {
-            cpuid(0x80000006, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[2],
-                &cpuid_info.cache_info.raw[3]
-            );
-        }
-        break;
-      case 'G':
-        // Intel Processors
-        // No cpuid info to read.
-        break;
+    if (cpuid_info.max_xcpuid >= 0x80000005) {
+        cpuid(0x80000005, 0,
+            &reg[0],
+            &reg[1],
+            &cpuid_info.cache_info.raw[0],
+            &cpuid_info.cache_info.raw[1]
+        );
+    }
+    if (cpuid_info.max_xcpuid >= 0x80000006) {
+        cpuid(0x80000006, 0,
+            &reg[0],
+            &reg[1],
+            &cpuid_info.cache_info.raw[2],
+            &cpuid_info.cache_info.raw[3]
+        );
     }
 
     // Detect CPU Topology (Core/Thread) infos


### PR DESCRIPTION
Always populate the cache info from extended CPUID, it is not used for Intel CPUs, even though it is present, and is useful for non-Intel CPUs.

Fix the CPU name and cache sizes for Centaur and Cyrix/NSC CPUs without brand string, which are the WinChip C6 and all Cyrix CPUs except the Media GXm.

For the Media GXm and Geode GXm/GXLV/GX1, which are available with both Cyrix and NSC vendor strings, hardcode the L1 cache size. The Geode GX2 uses standard cache info.