### PR TITLE
RFC: Add x86 BIOS boot code to header.S

### DIFF
--- a/boot/header.S
+++ b/boot/header.S
@@ -1,11 +1,23 @@
 // SPDX-License-Identifier: GPL-2.0
 //
-// header.S supports booting directly from a UEFI BIOS or via an intermediate
-// bootloader that supports the Linux boot protocol. When booted directly from
-// the BIOS, it provides the MS-DOS & PE/COFF headers. When using an intermediate
-// bootloader, it provides the first few bytes of the Linux boot header (at the
-// end of the boot sector), with the remainder of the header being provided by
-// setup.S.
+// header.S supports booting directly from the BIOS/UEFI or via an intermediate
+// bootloader that supports the Linux boot protocol. All-in-one.
+//
+// To support loading from the UEFI, it provides the MS-DOS & PE/COFF headers.
+//
+// When using an intermediate bootloader, it provides the first few bytes of
+// the Linux boot header (at the end of the boot sector), with the remainder
+// of the header being provided by setup.S.
+//
+// Finally, if booted directly from the BIOS, it gets loaded at address 0x7C00
+// with DL register set to the boot drive number: 0x0 - FDD, 0x80 - first HDD.
+// Once started, it creates a new Floppy Disk Drive parameter table and prints
+// boot_msg - "Loading". Next it tries to load setup.S immediately after itself
+// (address 0x7E00). Once succesfull, it prints " MT86+" and starts loading
+// the main program code at segment MAIN_SEG (address 0x10000), using BIOS
+// int 13h services to read the data from the disk. After each successfull read
+// a dot (.) is printed. When read fails, "X" gets printed and read operation is
+// restarted.
 //
 // Copyright (C) 2020 Martin Whitaker.
 //
@@ -32,52 +44,73 @@
 	.section ".header", "ax", @progbits
 	.code16
 
+# The BIOS boot entry point. This will be located at 0x7c00.
+
 	.globl	boot
 boot:
-	# "MZ", the MS-DOS header signature.
+	# "MZ", the MS-DOS header signature. Fortunately it translates
+	# to harmless x86 instructions.
 	.byte 0x4d
 	.byte 0x5a
 
-        # In case we are booted by a legacy BIOS, print an error message.
-        # Fortunately the MS-DOS header translates to harmless instructions.
+	# Initialize the segment registers and the stack.
 
-	ljmp	$BOOT_SEG, $(error - boot)
-error:
+	ljmp	$BOOT_SEG, $init
+init:
 	movw	%cs, %ax
 	movw	%ax, %ds
 	movw	%ax, %es
 	movw	%ax, %ss
-	xorw	%sp, %sp
-	sti
+
+	movw	$(BOOT_STACK_TOP - 12), %bp
+	movw	%bp, %sp
+
+	# Old BIOS's default disk parameter tables will not recognize
+	# multi-sector reads beyond the maximum sector number specified
+	# in the default diskette parameter tables - this may mean 7
+	# sectors in some cases.
+	#
+	# Since single sector reads are slow and out of the question,
+	# we must take care of this by creating new parameter tables
+	# (for the first disk) in RAM. We will set the maximum sector
+	# count to 18 - the most we will encounter on an HD 1.44.
+	#
+	# High doesn't hurt. Low does.
+	#
+	# Segments are as follows:
+	#	ds=es=ss=cs = BOOT_SEG,
+	#	fs = 0, gs = parameter table segment
+	#
+	# The table will be stored at the stack, taking 12 bytes.
+
+	xorw	%bx, %bx
+	movw	%bx, %fs
+	movb	$0x78, %bl
+	lgs	%fs:(%bx),%si		# Load source addr from fs:bx to gs:si
+
+	movw	%sp, %di		# Set es:di from ss:sp as the destination
+	movw	$6, %cx 		# copy 12 bytes
+
 	cld
+	rep	movsw %gs:(%si), %es:(%di)
 
-	movw	$error_msg, %si
-0:	lodsb
-	andb	%al, %al
-	jz	wait
-	movb	$0xe, %ah
-	movw	$7, %bx
+	movb	$18, %ss:4(%bp)		# patch sector count
+
+	movw	%bp, %fs:(%bx)
+	movw	%es, %fs:2(%bx)
+
+	# Called with bh=0
+	movb	$0x03, %ah		# Read cursor pos.
 	int	$0x10
-	jmp	0b
 
-wait:
-	# Allow the user to press a key, then reboot.
-	xorw	%ax, %ax
-	int	$0x16
-	int	$0x19
+	jmp	boot_done		# That's all that fits here, continue...
 
-	# int 0x19 should never return. In case it does, invoke the BIOS.
-        # reset code.
-	ljmp	$0xf000,$0xfff0
+sread: .word 1 + SETUP_SECS		# sectors read of the current track
 
-        # The PE header pointer.
+	# The PE header pointer.
 	.org	0x3c
 	.long	pe_header
 
-error_msg:
-	.ascii	"This is a UEFI bootable image\r\n"
-	.ascii	"\n"
-        .asciz  "Press any key to reboot\r\n"
 
 pe_header:
 	.ascii	"PE"
@@ -141,8 +174,11 @@ extra_header_fields:
 	.long	512				# FileAlignment
 	.word	0				# MajorOperatingSystemVersion
 	.word	0				# MinorOperatingSystemVersion
+head:					# Also variable: current head
 	.word	0				# MajorImageVersion
+track:					# Also variable: current track
 	.word	0				# MinorImageVersion
+sectors:				# Also variable: sector count=18/15/9
 	.word	0				# MajorSubsystemVersion
 	.word	0				# MinorSubsystemVersion
 	.long	0				# Win32VersionValue
@@ -181,6 +217,166 @@ section_table:
 	.word	0				# NumberOfRelocations
 	.word	0				# NumberOfLineNumbers
 	.long	0x60500020			# Characteristics (section flags)
+
+boot_done:
+	# Print the message. Called with bh=0, and dh, dl already set.
+
+	movw	$boot_msg, %bp
+	movw	$(boot_msg_end - boot_msg), %cx
+	movb	$0x07, %bl			# Attribute 7 (normal).
+	movw	$0x1301, %ax			# Write string, move cursor.
+	int	$0x10
+
+load_setup:
+	xorw	%dx, %dx			# dl=drive 0, dh=head 0 for below.
+	xorb	%ah, %ah
+	int	$0x13				# reset FDC
+
+	# Load the setup sectors directly after the boot block.
+	# Note that 'es' is already set up.
+
+	movw	$0x0002, %cx			# sector 2, track 0
+	movw	$0x0200, %bx			# address = 512, in BOOT_SEG
+	movw	$(0x0200 + SETUP_SECS), %ax	# service 2, nr of sectors
+						# (assume all on head 0, track 0)
+	int	$0x13				# read it.
+	jc	load_setup			# error - repeat
+
+	xor	%bx, %bx
+	movb	$0x03, %ah			# Read cursor pos.
+	int	$0x10
+
+	movw	$header_msg, %bp
+	movw	$(header_msg_end - header_msg), %cx
+	movb	$0x07, %bl			# Attribute 7 (normal).
+	movw	$0x1301, %ax			# Write string, move cursor.
+	int	$0x10
+
+load_setup_done:
+	# Get disk drive parameters, specifically number of sectors/track.
+	# It seems that there is no BIOS call to get the number of sectors.
+	# Guess 18 sectors if sector 18 can be read, 15 if sector 15 can be
+	# read. Otherwise guess 9.
+
+	movw	$MAIN_SEG, %ax
+	movw	%ax, %es
+	xorw	%bx, %bx 		# bx is starting address within segment
+
+	xorw	%dx, %dx		# drive 0, head 0
+	movw	$0x0012, %cx		# sector 18, track 0
+	movw	$0x0201, %ax		# service 2, 1 sector
+	int	$0x13
+	jnc	got_sectors
+	movb	$0x0f, %cl		# sector 15
+	movw	$0x0201, %ax		# service 2, 1 sector
+	int	$0x13
+	jnc	got_sectors
+	movb	$0x09, %cl
+
+got_sectors:
+	movw	%cx, %ds:sectors
+
+	# Load the main test program.
+	call	read_it
+
+	# FDD motor will be switches off via floppy_off() called from
+	# global_init().
+
+	# Fix up the Linux boot header to indicate we've loaded into low memory.
+	movl	$LOW_LOAD_ADDR, code32_start
+
+	# After that (everything loaded), we jump to the setup code loaded
+	# directly after the boot block.
+
+	ljmp	$SETUP_SEG, $0
+
+# This subroutine loads the system at address 0x10000, making sure no 64KB
+# boundaries are crossed. We try to load it as fast as possible, loading
+# whole tracks whenever we can.
+#
+# in:	es - starting address segment (normally 0x1000)
+#
+
+read_it:
+	# es:bx is already set to $MAIN_SEG:0 in load_setup_done
+
+rp_read:
+	movw	%es, %ax
+	subw	$MAIN_SEG, %ax		# have we loaded all yet?
+	cmpw	%ds:sys_size, %ax
+	jbe	ok1_read
+	ret
+ok1_read:
+	movw	%ds:sectors, %ax
+	subw	%ds:sread, %ax
+	movw	%ax, %cx
+	shlw	$9, %cx
+	addw	%bx, %cx
+	jnc	ok2_read
+	je	ok2_read
+	xorw	%ax, %ax
+	subw	%bx, %ax
+	shrw	$9, %ax
+ok2_read:
+	call	read_track
+	movw	%ax, %cx
+	add	%ds:sread, %ax
+	cmpw	%ds:sectors, %ax
+	jne	ok3_read
+	movw	$1, %ax
+	subw	head, %ax
+	jne	ok4_read
+	incw	track
+ok4_read:
+	movw	%ax, %ds:head
+	xorw	%ax, %ax
+ok3_read:
+	movw	%ax, %ds:sread
+	shlw	$9, %cx
+	addw	%cx, %bx
+	jnc	rp_read
+	movw	%es, %ax
+	addb	$0x10, %ah
+	movw	%ax, %es
+	xorw	%bx, %bx
+	jmp	rp_read
+
+read_track:
+	pusha
+	movw	$0x0e2e, %ax		# 0x2e = "."
+read_track_recover:
+	movw	$00007, %bx
+	int	$0x10
+	popa
+	pusha
+
+	movw	%ds:track, %dx
+	movw	%ds:sread, %cx
+	incw	%cx
+	movb	%dl, %ch
+	movw	%ds:head, %dx
+	movb	%dl, %dh
+	andw	$0x0100, %dx
+	movb	$2, %ah
+
+	int	$0x13
+	jc	bad_rt
+	popa
+	ret
+bad_rt:
+	xorb	%ah, %ah
+	int	$0x13			# Reset FDC, dl already points to the drive id
+
+	movw	$0x0e58, %ax		# Leave 0x58 = "X" to be printed
+	jmp	read_track_recover
+
+boot_msg:
+	.ascii "Loading"
+boot_msg_end:
+
+header_msg:
+	.ascii " MT86+"
+header_msg_end:
 
 # Emulate the Linux boot header, to allow loading by intermediate boot loaders.
 


### PR DESCRIPTION
Currently, Memtest86+ provides two (three counting mbr.S) different headers:
 - bootsect.S for booting from the legacy BIOS, used in memtest.bin.
 - header.S. for booting from the UEFI, used in memtest.efi. Both support loading by an intermediate bootloader. Also, both are derived from the Linux kernel, but from a very different chapter in its evolution. FDD loading was removed a very long time ago, many, many years before adding PE/COFF headers for UEFI. Also, the PE/COFF headers are large (even larger for x86-64) and take a lot of very limited space, leaving very almost no headroom for the actual code, making this a bit harder.

Harder but not impossible.

This commit adds BIOS boot code to header.S, which should eventually enable to maitain a single, all-in-one binary that can be booted either by an intermediate bootloader (such as GRUB or LILO), UEFI and BIOS. Easier, and less confusing for users, as I have seen cases when people assume memtest.bin is needed for non-UEFI systems, even if never intented for FDD loading.

Overall, the code is derived from bootsect.S with changes, most importantly:

- Print "Loading" message immediately after setting up the custom FDD parameter table. The sooner the better.

- Instead of overriding the beginning of the code (which assumes BIOS sets DH to 0 and DL=0 -> FDD), use stack for the FDD table. Yes, the current code in bootsect.S uses DX assuming it is 0 but never initializes it.

- Print "MT86+" after successfully loading setup.S. Not enough space for the full name. Yet. :)

- Remove register dump in case of error - no space for it. However, print "X" after each failed read. Less spammy and IMO may even work better for an average user who may not understand how int13h works.

- Use $MAIN_SEG in the sector count detection routine. Less memory touched, and can be immediately re-used later for more compact code.

- Replace %cs with %ds for accessing variables (shorter x86 instructions) and explicitly prefix all with %ds.

- Don't allocate space for variables that start with 0. Instead, locate them in the PC/COFF header. There are plenty of fields set to 0 there.

- Several other small changes here and there to make the code more compact and save instructions.

Probably not the final version ready to commit, but should be very close to it. Error handling works well for loading both setup.S and the main program code and the loader recovers from read failures (such as ejected disk, unreadable sectors) always booting a working Memtest86+ if only the errors were transient. Tested multiple times. ;)

Also, while there are several other options for fitting more code, which I plan to explore later, for now I tried this to be as least disruptive as possible - no changes have been made to build files, memtest.bin nor anywhere outside header.S. All it does is to allow BIOS to boot memtest.efi, keeping the existing PE/COFF headers untouched.

That said, at some point it may make sense to consider removing memtest.bin which should also allow to simplify the Makefiles. We are definitely not there yet.